### PR TITLE
chore: update plugin-vue to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/tinycolor2": "^1.4.3",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "@vitejs/plugin-vue": "^1.6.1",
+    "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^1.1.8",
     "@vue/compiler-sfc": "^3.2.6",
     "@vue/eslint-config-prettier": "^6.0.0",


### PR DESCRIPTION
## Summary
- bump @vitejs/plugin-vue to v4

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aesoper%2fnormal-utils)*

------
https://chatgpt.com/codex/tasks/task_e_68be288109308331836e5fd112ffc8b3